### PR TITLE
Allow user to specify a cache key

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,9 @@ import CacheManager from 'relay-cache-manager';
 const cacheManager = new CacheManager();
 Relay.Store.getStoreData().injectCacheManager(cacheManager);
 ```
+
+If you wish, you can specify a key for the cache to use in the constructor, like so:
+
+```js
+const cacheManager = new CacheManager('testCacheKey');
+```

--- a/index.js
+++ b/index.js
@@ -54,9 +54,10 @@ class CacheRecordStore {
  *  to manage the CacheRecord instances
  */
 class CacheWriter {
-  constructor() {
+  constructor(cacheKey) {
+    this.cacheKey = cacheKey;
     try {
-      let localCache = localStorage.getItem(CACHE_KEY);
+      let localCache = localStorage.getItem(this.cacheKey);
       if (localCache) {
         localCache = JSON.parse(localCache);
         this.cache = CacheRecordStore.fromJSON(localCache);
@@ -80,7 +81,7 @@ class CacheWriter {
     this.cache.records[dataId] = record;
     try {
       const serialized = JSON.stringify(this.cache);
-      localStorage.setItem(CACHE_KEY, serialized);
+      localStorage.setItem(this.cacheKey, serialized);
     } catch (err) {
       /* noop */
     }
@@ -107,8 +108,8 @@ class CacheWriter {
 }
 
 export default class RelayCacheManager {
-  constructor() {
-    this.cacheWriter = new CacheWriter();
+  constructor(cacheKey = CACHE_KEY) {
+    this.cacheWriter = new CacheWriter(cacheKey);
   }
   clear() {
     return;


### PR DESCRIPTION
#### Overview

This PR adds a parameter to the CacheManager constructor allowing the user to pass in a key to use in localStorage. Although Relay should have no problem dealing with a single cache for multiple environments, I think it would be nice to allow users to enforce that separation in case they run into unforeseen issues. 
